### PR TITLE
17:  Fix "Cannot get class GitPlugin" error

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -15,11 +15,6 @@ run/main_scene="uid://c2gb4uegaq7bf"
 config/features=PackedStringArray("4.4", "Forward Plus")
 config/icon="res://icon.svg"
 
-[editor]
-
-version_control/plugin_name="GitPlugin"
-version_control/autoload_on_startup=true
-
 [input]
 
 move_forward={


### PR DESCRIPTION
This pull request includes a change to the `project.godot` file, specifically removing configuration related to the version control plugin. The change eliminates the `editor` section, which contained settings for the `GitPlugin`.

Key change:

* [`project.godot`](diffhunk://#diff-88c173602c6c7ccaaba6f408d21c235bda4d6884e30e71e73e1b07b9f93ad7b6L18-L22): Removed the `editor` section, including the `version_control/plugin_name` and `version_control/autoload_on_startup` settings, effectively disabling the Git version control plugin.