### PR TITLE
26: Fix crouch bug

### DIFF
--- a/src/Player/player.gd
+++ b/src/Player/player.gd
@@ -56,13 +56,13 @@ func _process(delta: float) -> void:
 	direction = direction.normalized()
 	if Input.get_action_strength("crouch"):
 		crouch_value = crouch_speed_multiplier
-		camera.position.y = crouching_height
+		twist_pivot.position.y = crouching_height
 	elif Input.get_action_strength("sprint") and input[1] < 0.0:
 		# if the player is moving forward and trying to sprint
 		sprint_value = sprint_speed_multiplier
-		camera.position.y = standing_height
+		twist_pivot.position.y = standing_height
 	else:
-		camera.position.y = standing_height
+		twist_pivot.position.y = standing_height
 	velocity = velocity.move_toward(direction * speed * crouch_value * sprint_value, acceleration * delta)
 	var mapped_input = map_direction(input)
 	var velocity_2d = Vector2.ZERO


### PR DESCRIPTION
This pull request modifies the player movement logic in `src/Player/player.gd` by replacing the use of `camera.position.y` with `twist_pivot.position.y` to adjust the vertical position during crouching and sprinting. This change likely reflects a shift in how the player's vertical position is managed, potentially improving the structure or functionality of the code.

Key changes in player movement logic:

* [`src/Player/player.gd`](diffhunk://#diff-1af4dcdf48c1b496f890903c6ecf34b2eaacdbb255ad72d1afe73a50fa2914a8L59-R65): Updated the vertical position adjustments during crouching and sprinting to use `twist_pivot.position.y` instead of `camera.position.y`. This affects the `crouching_height` and `standing_height` values in the `_process` method.