### PR TITLE
68: Interactable label rotation

### DIFF
--- a/src/common/DamageRay/demo/DamageRayDemo.tscn
+++ b/src/common/DamageRay/demo/DamageRayDemo.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=24 format=3 uid="uid://bmvg2shn15oom"]
 
-[ext_resource type="PackedScene" uid="uid://roylxbx2fqwt" path="res://src/common/demo/ExampleDemo.tscn" id="1_2tspk"]
+[ext_resource type="PackedScene" uid="uid://b2wqxfwdm7a" path="res://src/common/demo/ExampleDemo.tscn" id="1_2tspk"]
 [ext_resource type="PackedScene" uid="uid://cdc3ubfifx2di" path="res://src/common/DamageRay/demo/ItemToDestroy.tscn" id="2_kaiyn"]
 [ext_resource type="PackedScene" uid="uid://blxoss2f6pgqo" path="res://src/common/DamageRay/demo/GunItem.tscn" id="3_k2c8t"]
 [ext_resource type="Script" uid="uid://cnm1cu0ohx7uv" path="res://src/common/DamageRay/demo/gun_item.gd" id="4_dpbh2"]

--- a/src/common/Interactable/Interactable.gd
+++ b/src/common/Interactable/Interactable.gd
@@ -25,9 +25,11 @@ signal interacted(body)
 @export_enum("Once", "Continuous") var interaction_mode: String = "Once"
 
 @onready var label: Label3D = $Label3D
+@onready var label_initial_local_transform = label.transform.origin
 
 var _key_name: String
 var _timeout_left: float = 0.0
+
 
 func _ready() -> void:
 	self.collision_layer = Bits.from([Layer.Interactables])
@@ -35,6 +37,7 @@ func _ready() -> void:
 	self.label.billboard = BaseMaterial3D.BILLBOARD_ENABLED # Make the label always face the Player
 	self._key_name = _get_key()
 	self.label.text = get_prompt()
+
 	hide_label()
 
 func interact(body):
@@ -44,10 +47,13 @@ func interact(body):
 	interacted.emit(body)
 	_timeout_left = interaction_timeout
 
-## Handles counting down the potential interaction timeout
-func _process(delta: float) -> void:	
+func _process(delta: float) -> void:
+	# Handles counting down the potential interaction timeout
 	if _timeout_left > 0:
 		_timeout_left -= delta
+		
+	# Make the label disregard the parent's rotation
+	label.global_position = self.global_position + label_initial_local_transform
 	
 func get_prompt() -> String:
 	if not displays_prompt:

--- a/src/common/Interactable/demo/InteractableBox.tscn
+++ b/src/common/Interactable/demo/InteractableBox.tscn
@@ -22,6 +22,11 @@ mesh = SubResource("BoxMesh_4c07q")
 shape = SubResource("ConvexPolygonShape3D_575tu")
 
 [node name="Label3D" type="Label3D" parent="."]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.379453, 0)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.4, 0)
+pixel_size = 0.001
+no_depth_test = true
+fixed_size = true
+font_size = 45
+outline_size = 14
 
 [connection signal="interacted" from="." to="." method="_on_interacted"]

--- a/src/common/Interactable/demo/InteractableDemo.tscn
+++ b/src/common/Interactable/demo/InteractableDemo.tscn
@@ -17,7 +17,7 @@ prompt_message = "Continuous"
 interaction_mode = "Continuous"
 
 [node name="InteractableBox3" parent="." instance=ExtResource("2_er83y")]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 1.58781, 1.91793, 0)
+transform = Transform3D(1, 0, 0, 0, 1, 0.000506145, 0, -0.000506145, 1, 1.58781, 1.91793, 0)
 prompt_message = "Timeout"
 interaction_timeout = 0.5
 interaction_mode = "Continuous"
@@ -30,3 +30,15 @@ is_interaction_enabled = false
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 2.00262, 0.988594, 0)
 text = "Disabled
 interaction"
+
+[node name="InteractableBox5" parent="." instance=ExtResource("2_er83y")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 1.97955, 1.24558, 0)
+is_interaction_enabled = false
+
+[node name="InteractableBox6" parent="." instance=ExtResource("2_er83y")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 1.97955, 1.24558, 0)
+is_interaction_enabled = false
+
+[node name="InteractableBox7" parent="." instance=ExtResource("2_er83y")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 1.57955, 0.24558, 0)
+is_interaction_enabled = false


### PR DESCRIPTION
Fixes #68 and #53 


This pull request includes updates to improve the functionality and appearance of interactable objects in the demo scenes, as well as minor fixes to resource references. The most important changes include adjustments to the `Interactable` script for label positioning, enhancements to the `InteractableBox` node's visual properties, and updates to demo scenes to add more interactable elements and correct resource references.

### Script Improvements for Interactable Objects:
* In `src/common/Interactable/Interactable.gd`, added `label_initial_local_transform` to store the label's initial position and updated `_process` to ensure the label disregards the parent's rotation, keeping it visually consistent. [[1]](diffhunk://#diff-d7b3c7b50d752f45492056bf7c3f086611be1c340aa1311612e09ae78af386d2R28-R40) [[2]](diffhunk://#diff-d7b3c7b50d752f45492056bf7c3f086611be1c340aa1311612e09ae78af386d2L47-R57)

### Visual Enhancements to InteractableBox:
* In `src/common/Interactable/demo/InteractableBox.tscn`, adjusted the `Label3D` node's properties by adding `pixel_size`, `no_depth_test`, `fixed_size`, `font_size`, and `outline_size` for better readability and appearance.

### Updates to Demo Scenes:
* In `src/common/Interactable/demo/InteractableDemo.tscn`, added multiple new `InteractableBox` nodes (`InteractableBox5`, `InteractableBox6`, and `InteractableBox7`) with `is_interaction_enabled = false` for more diverse examples in the scene.
* Adjusted the `transform` of `InteractableBox3` in the same file to refine its positioning.

### Resource Reference Fix:
* In `src/common/DamageRay/demo/DamageRayDemo.tscn`, updated the `ext_resource` reference for `ExampleDemo.tscn` to point to the correct resource path.