### PR TITLE
69: Cannot use items while crouched

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -83,6 +83,7 @@ interact={
 use_item={
 "deadzone": 0.2,
 "events": [Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"button_mask":0,"position":Vector2(0, 0),"global_position":Vector2(0, 0),"factor":1.0,"button_index":1,"canceled":false,"pressed":false,"double_click":false,"script":null)
+, Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":true,"meta_pressed":false,"button_mask":0,"position":Vector2(0, 0),"global_position":Vector2(0, 0),"factor":1.0,"button_index":2,"canceled":false,"pressed":false,"double_click":false,"script":null)
 ]
 }
 toggle_flashlight={


### PR DESCRIPTION
macOS issue
This pull request updates the `interact` functionality in the `project.godot` file to add a new input event for toggling actions. The most important change is the addition of a new `InputEventMouseButton` configuration.

Input event updates:

* [`project.godot`](diffhunk://#diff-88c173602c6c7ccaaba6f408d21c235bda4d6884e30e71e73e1b07b9f93ad7b6R86): Added a new `InputEventMouseButton` configuration with `ctrl_pressed: true` and `button_index: 2` to the `use_item` event list, enabling an additional mouse interaction.