### PR TITLE
89: Implement third person dev camera

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -105,6 +105,11 @@ dev_free_cursor={
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":true,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":67,"key_label":0,"unicode":263,"location":0,"echo":false,"script":null)
 ]
 }
+dev_third_person_camera={
+"deadzone": 0.2,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":true,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":84,"key_label":0,"unicode":8224,"location":0,"echo":false,"script":null)
+]
+}
 
 [layer_names]
 

--- a/src/Player/player.gd
+++ b/src/Player/player.gd
@@ -3,12 +3,12 @@ extends CharacterBody3D
 class_name Player
 
 # TODO: replace this with a config value that's taken from the game settings
-@export_group("mouse")
+@export_group("Mouse")
 @export var mouse_sensitivity := 0.001
 @export var mouse_twist := 0.0
 @export var mouse_pitch := 0.0
 
-@export_group("player_properties")
+@export_group("Movement")
 @export var speed = 4.0
 @export var acceleration = 80.0
 @export var sprint_speed_multiplier = 2.0
@@ -23,6 +23,9 @@ class_name Player
 # if there is no gravity, the player can jump, but not move up/down freely.
 # the reverse happens if there is no gravity.
 @export var no_gravity_mode := 0
+
+@export_group("Debug")
+@export var third_person_camera_distance := 2.0
 
 @onready var twist_pivot: Node3D = $TwistPivot
 @onready var pitch_pivot: Node3D = $TwistPivot/PitchPivot
@@ -105,6 +108,12 @@ func _process(delta: float) -> void:
 	
 	if Input.is_action_just_pressed("dev_free_cursor"):
 		Input.set_mouse_mode(Input.MOUSE_MODE_VISIBLE)
+	
+	if Input.is_action_just_pressed("dev_third_person_camera"):
+		if camera.position.z == 0:
+			camera.position.z = third_person_camera_distance
+		else:
+			camera.position.z = 0
 		
 	twist_pivot.rotate_y(mouse_twist)
 	pitch_pivot.rotate_x(mouse_pitch)

--- a/src/Player/player.gd
+++ b/src/Player/player.gd
@@ -25,6 +25,7 @@ class_name Player
 @export var no_gravity_mode := 0
 
 @export_group("Debug")
+@export var third_person_camera := false
 @export var third_person_camera_distance := 2.0
 
 @onready var twist_pivot: Node3D = $TwistPivot
@@ -110,10 +111,12 @@ func _process(delta: float) -> void:
 		Input.set_mouse_mode(Input.MOUSE_MODE_VISIBLE)
 	
 	if Input.is_action_just_pressed("dev_third_person_camera"):
-		if camera.position.z == 0:
-			camera.position.z = third_person_camera_distance
+		if third_person_camera:
+			camera.position.z -= third_person_camera_distance
+			third_person_camera = false
 		else:
-			camera.position.z = 0
+			camera.position.z += third_person_camera_distance
+			third_person_camera = true
 		
 	twist_pivot.rotate_y(mouse_twist)
 	pitch_pivot.rotate_x(mouse_pitch)


### PR DESCRIPTION
This pull request introduces a new developer feature for toggling a third-person camera mode, along with some minor code organization improvements. The most important changes include adding a new input action for toggling the third-person camera, exposing a configurable camera distance, and reorganizing export groups for better clarity.

### New Developer Feature: Third-Person Camera Toggle

* **Added third-person camera input action:** Introduced a new input action, `dev_third_person_camera`, in the `project.godot` configuration file. This action allows toggling the camera's position between first-person and third-person views. (`project.godot`, [project.godotR108-R112](diffhunk://#diff-88c173602c6c7ccaaba6f408d21c235bda4d6884e30e71e73e1b07b9f93ad7b6R108-R112))
* **Implemented third-person camera toggle logic:** Added logic in the `_process` function to handle the `dev_third_person_camera` input action. The camera's `z` position is toggled between `0` (first-person) and the configurable `third_person_camera_distance`. (`src/Player/player.gd`, [src/Player/player.gdR112-R117](diffhunk://#diff-1af4dcdf48c1b496f890903c6ecf34b2eaacdbb255ad72d1afe73a50fa2914a8R112-R117))
* **Exposed third-person camera distance:** Added a new exported variable, `third_person_camera_distance`, under a new `Debug` export group. This variable allows developers to configure the distance of the third-person camera. (`src/Player/player.gd`, [src/Player/player.gdR27-R29](diffhunk://#diff-1af4dcdf48c1b496f890903c6ecf34b2eaacdbb255ad72d1afe73a50fa2914a8R27-R29))

### Code Organization Improvements

* **Reorganized export groups:** Renamed `@export_group` labels for better clarity. The "mouse" group was renamed to "Mouse," and the "player_properties" group was renamed to "Movement." (`src/Player/player.gd`, [src/Player/player.gdL6-R11](diffhunk://#diff-1af4dcdf48c1b496f890903c6ecf34b2eaacdbb255ad72d1afe73a50fa2914a8L6-R11))